### PR TITLE
making the default externally accessible

### DIFF
--- a/gosnmp.go
+++ b/gosnmp.go
@@ -552,9 +552,8 @@ func (x *GoSNMP) WalkAll(rootOid string) (results []SnmpPDU, err error) {
 // length 3, Partition returns true for the currentPosition having
 // the following values:
 //
-// 0  1  2  3  4  5  6  7
-//
-//	T        T     T
+//	0  1  2  3  4  5  6  7
+//	      T        T     T
 func Partition(currentPosition, partitionSize, sliceLength int) bool {
 	if currentPosition < 0 || currentPosition >= sliceLength {
 		return false

--- a/gosnmp.go
+++ b/gosnmp.go
@@ -32,7 +32,7 @@ const (
 	baseOid = ".1.3.6.1.2.1"
 
 	// Java SNMP uses 50, snmp-net uses 10
-	defaultMaxRepetitions = 50
+	DefaultMaxRepetitions = 50
 )
 
 // GoSNMP represents GoSNMP library state
@@ -81,7 +81,7 @@ type GoSNMP struct {
 	MaxOids int
 
 	// MaxRepetitions sets the GETBULK max-repetitions used by BulkWalk*
-	// Unless MaxRepetitions is specified it will use defaultMaxRepetitions (50)
+	// Unless MaxRepetitions is specified it will use DefaultMaxRepetitions (50)
 	// This may cause issues with some devices, if so set MaxRepetitions lower.
 	// See comments in https://github.com/soniah/gosnmp/issues/100
 	MaxRepetitions uint8
@@ -239,8 +239,9 @@ func (x *GoSNMP) ConnectIPv6() error {
 // connect to address addr on the given network
 //
 // https://golang.org/pkg/net/#Dial gives acceptable network values as:
-//   "tcp", "tcp4" (IPv4-only), "tcp6" (IPv6-only), "udp", "udp4" (IPv4-only),"udp6" (IPv6-only), "ip",
-//   "ip4" (IPv4-only), "ip6" (IPv6-only), "unix", "unixgram" and "unixpacket"
+//
+//	"tcp", "tcp4" (IPv4-only), "tcp6" (IPv6-only), "udp", "udp4" (IPv4-only),"udp6" (IPv6-only), "ip",
+//	"ip4" (IPv4-only), "ip6" (IPv6-only), "unix", "unixgram" and "unixpacket"
 func (x *GoSNMP) connect(networkSuffix string) error {
 	err := x.validateParameters()
 	if err != nil {
@@ -552,8 +553,8 @@ func (x *GoSNMP) WalkAll(rootOid string) (results []SnmpPDU, err error) {
 // the following values:
 //
 // 0  1  2  3  4  5  6  7
-//       T        T     T
 //
+//	T        T     T
 func Partition(currentPosition, partitionSize, sliceLength int) bool {
 	if currentPosition < 0 || currentPosition >= sliceLength {
 		return false

--- a/walk.go
+++ b/walk.go
@@ -9,6 +9,9 @@ import (
 	"strings"
 )
 
+// walks the specified oid.
+//
+//	note we set maxRepetitions to the DefaultMaxRepetitions (50) if it is zero
 func (x *GoSNMP) walk(getRequestType PDUType, rootOid string, walkFn WalkFunc) error {
 	if rootOid == "" || rootOid == "." {
 		rootOid = baseOid
@@ -22,7 +25,7 @@ func (x *GoSNMP) walk(getRequestType PDUType, rootOid string, walkFn WalkFunc) e
 	requests := 0
 	maxReps := x.MaxRepetitions
 	if maxReps == 0 {
-		maxReps = defaultMaxRepetitions
+		maxReps = DefaultMaxRepetitions
 	}
 
 	// AppOpt 'c: do not check returned OIDs are increasing'


### PR DESCRIPTION
this code is hidden in gosnmp walk https://github.com/kentik/gosnmp/blob/55c0b93f05f28660e268d99e65681984bb56d725/walk.go#L27-L29 

i want to be able to set this explicitly in our code. so we can log what it is 